### PR TITLE
Allow swapping out PromQL engine in web API

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -133,11 +133,16 @@ type TSDBAdmin interface {
 	Snapshot(dir string, withHead bool) error
 }
 
+type PromQLEngine interface {
+	NewInstantQuery(q storage.Queryable, qs string, ts time.Time) (promql.Query, error)
+	NewRangeQuery(q storage.Queryable, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
+}
+
 // API can register a set of endpoints in a router and handle
 // them using the provided storage and query engine.
 type API struct {
 	Queryable   storage.Queryable
-	QueryEngine *promql.Engine
+	QueryEngine PromQLEngine
 
 	targetRetriever       targetRetriever
 	alertmanagerRetriever alertmanagerRetriever
@@ -162,7 +167,7 @@ func init() {
 
 // NewAPI returns an initialized API type.
 func NewAPI(
-	qe *promql.Engine,
+	qe PromQLEngine,
 	q storage.Queryable,
 	tr targetRetriever,
 	ar alertmanagerRetriever,


### PR DESCRIPTION
Currently we allow swapping out the Queryable that the *promql.Engine uses, but
if one wants to implement PromQL evaluation by an entirely different mechanism
than the *promql.Engine, this upper layer also needs to be swappable. The
concrete motivation for this is for adding a Prometheus API endpoint to
InfluxDB which handles PromQL queries by transpiling them to Flux and then
executing the resulting Flux query instead.

Signed-off-by: Julius Volz <julius.volz@gmail.com>

<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
